### PR TITLE
Add weighted combination loss for multitask

### DIFF
--- a/strix/models/__init__.py
+++ b/strix/models/__init__.py
@@ -156,9 +156,9 @@ def get_engine(opts, train_loader, test_loader, writer=None):
 
     loss = lr_scheduler = None
     if opts.framework == Frameworks.MULTITASK.value:
-        subloss1 = get_loss_fn(opts.subtask1, opts.criterion[0], opts.loss_params_task1, opts.output_nc[0], opts.deep_supervision)
-        subloss2 = get_loss_fn(opts.subtask2, opts.criterion[1], opts.loss_params_task2, opts.output_nc[1], opts.deep_supervision)
-        loss = LOSS_MAPPING[opts.framework]["CombinationLoss"](subloss1, subloss2, aggregate="sum")
+        subloss1 = get_loss_fn(opts.subtask1, opts.criterion[1], opts.loss_params_task1, opts.output_nc[0], opts.deep_supervision)
+        subloss2 = get_loss_fn(opts.subtask2, opts.criterion[2], opts.loss_params_task2, opts.output_nc[1], opts.deep_supervision)
+        loss = LOSS_MAPPING[opts.framework][opts.criterion[0]](subloss1, subloss2, aggregate="sum", **opts.loss_params)
     else:
         loss = get_loss_fn(opts.framework, opts.criterion, opts.loss_params, opts.output_nc, opts.deep_supervision)
 

--- a/strix/models/cnn/losses/__init__.py
+++ b/strix/models/cnn/losses/__init__.py
@@ -49,4 +49,5 @@ SIAMESE_LOSS.register('ContrastiveBCELoss', ContrastiveBCELoss)
 
 SELFLEARNING_LOSS.register('MSE', torch.nn.MSELoss)
 
-MULTITASK_LOSS.register("CombinationLoss", CombinationLoss)
+MULTITASK_LOSS.register("Uniform", CombinationLoss)
+MULTITASK_LOSS.register("Weighted", CombinationLoss)

--- a/strix/models/cnn/losses/losses.py
+++ b/strix/models/cnn/losses/losses.py
@@ -147,12 +147,13 @@ class DeepSupervisionLoss(Module):
 
 
 class CombinationLoss(Module):
-    def __init__(self, loss1: Callable, loss2: Callable, aggregate: str = "sum", ensure_dim: bool = True):
+    def __init__(self, loss1: Callable, loss2: Callable, aggregate: str = "sum", weight: float = 1.0, ensure_dim: bool = True):
         super(CombinationLoss, self).__init__()
         self.aggregate = aggregate
         self.ensure_dim = ensure_dim
         self.loss1 = loss1
         self.loss2 = loss2
+        self.weight = weight
 
     def forward(self, net_output, target):
         if not isinstance(net_output, tuple) or len(net_output) != 2:
@@ -169,7 +170,7 @@ class CombinationLoss(Module):
             loss2_output = self.loss2(net_output[1], target[1])
 
         if self.aggregate == "sum":
-            result = loss1_output + loss2_output
+            result = self.weight * loss1_output + loss2_output
         else:
             raise NotImplementedError
         return result

--- a/strix/tests/test_click_second_option.py
+++ b/strix/tests/test_click_second_option.py
@@ -1,4 +1,3 @@
-from email.policy import default
 import click
 from click import UNPROCESSED
 import pytest

--- a/strix/tests/test_loss_selection.py
+++ b/strix/tests/test_loss_selection.py
@@ -1,0 +1,25 @@
+import click
+from click import UNPROCESSED
+from functools import partial
+import pytest
+from strix.utilities.click import OptionEx, CommandEx
+from strix.utilities.click_callbacks import loss_select
+
+option = partial(click.option, cls=OptionEx)
+command = partial(click.command, cls=CommandEx)
+
+@pytest.mark.parametrize('value', ["1", "2"])
+def test_multitask_loss(value, runner, tmp_path):
+    @command()
+    @option("--framework", type=str, default="multitask")
+    @option("--criterion", type=UNPROCESSED, callback=loss_select, default=None, help="loss criterion type")
+    def cli_test_case(framework, criterion):
+        print("criterion:", criterion)
+
+    result = runner.invoke(cli_test_case, [], input=value)
+    if value == "1":
+        assert "Input Weight" not in result.output
+    elif value == "2":
+        assert "Input Weight" in result.output
+
+


### PR DESCRIPTION
Aded `weight` arg to `CombinationLoss`.
Now `CombinationLoss` divided into "Uniform" and "Weighted" two loss fn.

Adjust multitask loss selection logic.
Added unitest.