### PR TITLE
:boom: Rename all `files_list` to `filelist` in dataset

### DIFF
--- a/strix/data_io/base_dataset/classification_dataset.py
+++ b/strix/data_io/base_dataset/classification_dataset.py
@@ -9,7 +9,7 @@ from strix.data_io.base_dataset.utils import get_input_data
 class BasicClassificationDataset(object):
     def __new__(
         self,
-        files_list: Sequence,
+        filelist: Sequence,
         loader: Union[Sequence[MapTransform], MapTransform],
         channeler: Union[Sequence[MapTransform], MapTransform],
         orienter: Union[Sequence[MapTransform], MapTransform],
@@ -26,16 +26,16 @@ class BasicClassificationDataset(object):
         check_data: bool = True,
         verbose: bool = False,
     ):
-        self.files_list = files_list
+        self.filelist = filelist
         self.verbose = verbose
         self.dataset = dataset_type
         self.dataset_kwargs = dataset_kwargs
         if check_data:
             self.input_data = get_input_data(
-                files_list, is_supervised, verbose, self.__class__.__name__
+                filelist, is_supervised, verbose, self.__class__.__name__
             )
         else:
-            self.input_data = files_list
+            self.input_data = filelist
 
         self.transforms = ensure_list(loader)
         if channeler is not None:

--- a/strix/data_io/base_dataset/segmentation_dataset.py
+++ b/strix/data_io/base_dataset/segmentation_dataset.py
@@ -10,7 +10,7 @@ from strix.data_io.base_dataset.utils import get_input_data
 class BasicSegmentationDataset(object):
     def __new__(
         self,
-        files_list: Sequence,
+        filelist: Sequence,
         loader: Union[Sequence[MapTransform], MapTransform],
         channeler: Union[Sequence[MapTransform], MapTransform],
         orienter: Union[Sequence[MapTransform], MapTransform],
@@ -27,16 +27,16 @@ class BasicSegmentationDataset(object):
         check_data: bool = True,
         verbose: bool = False,
     ):
-        self.files_list = files_list
+        self.filelist = filelist
         self.verbose = verbose
         self.dataset = dataset_type
         self.dataset_kwargs = dataset_kwargs
         if check_data:
             self.input_data = get_input_data(
-                files_list, is_supervised, verbose, self.__class__.__name__
+                filelist, is_supervised, verbose, self.__class__.__name__
             )
         else:
-            self.input_data = files_list
+            self.input_data = filelist
 
         self.transforms = ensure_list(loader)
         if channeler is not None:

--- a/strix/data_io/base_dataset/selflearning_dataset.py
+++ b/strix/data_io/base_dataset/selflearning_dataset.py
@@ -11,7 +11,7 @@ from strix.data_io.base_dataset.utils import get_input_data
 class BasicSelflearningDataset(object):
     def __new__(
         self,
-        files_list: Sequence,
+        filelist: Sequence,
         loader: Union[Sequence[MapTransform], MapTransform],
         channeler: Union[Sequence[MapTransform], MapTransform],
         orienter: Union[Sequence[MapTransform], MapTransform],
@@ -27,16 +27,16 @@ class BasicSelflearningDataset(object):
         check_data: bool = True,
         verbose: bool = False,
     ):
-        self.files_list = files_list
+        self.filelist = filelist
         self.verbose = verbose
         self.dataset = dataset_type
         self.dataset_kwargs = dataset_kwargs
         if check_data:
             self.input_data = get_input_data(
-                files_list, False, verbose, self.__class__.__name__
+                filelist, False, verbose, self.__class__.__name__
             )
         else:
-            self.input_data = files_list
+            self.input_data = filelist
 
         self.transforms = ensure_list(loader)
         if channeler is not None:

--- a/strix/data_io/base_dataset/siamese_dataset.py
+++ b/strix/data_io/base_dataset/siamese_dataset.py
@@ -64,7 +64,7 @@ class SiameseDatasetWrapper(Dataset):
 class BasicSiameseDataset(BasicClassificationDataset):
     def __new__(
         self,
-        files_list: Sequence,
+        filelist: Sequence,
         loader: Union[Sequence[MapTransform], MapTransform],
         channeler: Union[Sequence[MapTransform], MapTransform],
         orienter: Union[Sequence[MapTransform], MapTransform],
@@ -81,7 +81,7 @@ class BasicSiameseDataset(BasicClassificationDataset):
         verbose: Optional[bool] = False,
     ) -> None:
         super().__init__(
-            files_list=files_list,
+            filelist=filelist,
             loader=loader,
             channeler=channeler,
             orienter=orienter,

--- a/strix/data_io/generate_dataset.py
+++ b/strix/data_io/generate_dataset.py
@@ -17,7 +17,7 @@ root_tree = {
         "FRAMEWORK": "",
         "KEYS": ("image", "label"),
         "PHASE": ("train", "valid", "test"),
-        "FILES_LIST": "",
+        "FILELIST": "",
     },
     "PREPROCESS": {
         "LOADER": {},
@@ -69,10 +69,10 @@ def parse_dataset_config(configs):
     check_config(
         configs, key=["ATTRIBUTE", "PHASE"], candidates=["train", "valid", "test"]
     )
-    check_config(configs, key=["ATTRIBUTE", "FILES_LIST"])
+    check_config(configs, key=["ATTRIBUTE", "FILELIST"])
     check_config(configs, key=["PREPROCESS", "LOADER"])
 
-    file_list = configs["ATTRIBUTE"]["FILES_LIST"]
+    file_list = configs["ATTRIBUTE"]["FILELIST"]
     assert os.path.isfile(file_list), f"File list not exist! {file_list}"
 
     default_keys = configs["ATTRIBUTE"]["KEYS"]
@@ -233,7 +233,7 @@ def register_dataset_from_cfg(config_path):
     DATASET_MAPPING[configs["ATTRIBUTE"]["FRAMEWORK"]].register(
         configs["ATTRIBUTE"]["DIM"],
         configs["ATTRIBUTE"]["NAME"],
-        configs["ATTRIBUTE"]["FILES_LIST"],
+        configs["ATTRIBUTE"]["FILELIST"],
         partial(
             create_dataset_from_cfg,
             datasets=datasets_,
@@ -256,7 +256,7 @@ def test_dataset_from_config(config_path, phase, opts):
         )
     )
     dataset = create_dataset_from_cfg(
-        get_items_from_file(configs["ATTRIBUTE"]["FILES_LIST"], format='auto'),
+        get_items_from_file(configs["ATTRIBUTE"]["FILELIST"], format='auto'),
         phase,
         opts,
         datasets_,

--- a/strix/datasets/README.md
+++ b/strix/datasets/README.md
@@ -7,13 +7,13 @@
     from monai_ex.transforms import *
 
     @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '\homes\my_dataset_fname.json')
-    def get_my_dataset(files_list, phase, opts):
+    def get_my_dataset(filelist, phase, opts):
         # Get parameters you need for creating your dataset
         preload=opts.get('preload', 1.0)
         augment_ratio=opts.get('augment_ratio', 0.5)
 
         dataset = BasicClassificationDataset(
-            files_list,
+            filelist,
             loader = LoadImageD(keys="image"),
             channeler = AddChannelD(keys="image"),
             orienter = OrientationD(keys="image", axcodes="LPI"),
@@ -34,7 +34,7 @@ In the given example, `my_dataset` has been registered to a `2D classification` 
 
 1. import base dataset type `CLASSIFICATION_DATASETS`/`SEGMENTATION_DATASETS`/`SELFLEARNING_DATASETS`/`MULTITASK_DATASETS`.
 2. Define your dataset function, with 3 arguments:
-    - files_list: handle your input data list
+    - filelist: handle your input data list
     - phase: including 4 different stages `Phases.TRAIN`, `Phases.VALID`, `Phases.TEST_IN` and `Phases.TEST_EX`
       - `Phases` is imported from `strix.utilities.enum import Phases`
       - `Phases.TEST_IN` means internal test w/ ground-truth, `Phases.TEST_EX` means external test w/o gt.
@@ -50,31 +50,31 @@ In the given example, `my_dataset` has been registered to a `2D classification` 
 - ### If you want reuse your dataset function for multiple dataset but with different training data. You can add multiple decorators like:
         @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '/homes/my_dataset_fname.json')
         @CLASSIFICATION_DATASETS.register('2D', 'my_dataset_2', '/homes/my_dataset_fname_2.json')
-        def get_my_dataset(files_list, phase, opts):
+        def get_my_dataset(filelist, phase, opts):
             pass
 
 
 - ### Notice that ONLY registered dataset can used in Strix. If you want remove one dataset, you can simply remove its decorator instead.
         # @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '/homes/my_dataset_fname.json') <- Comment this!
-        def get_my_dataset(files_list, phase, opts):
+        def get_my_dataset(filelist, phase, opts):
             print("Not used")
 
 - ### If you have want to save/snapshot your dataset. You can use `snapshot` decorator! Your `my_dataset.py` will be automatically saved to your experimental dir.
         @CLASSIFICATION_DATASETS.snapshot
         @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '/homes/my_dataset_fname.json')
-        def get_my_dataset(files_list, phase, opts):
+        def get_my_dataset(filelist, phase, opts):
             pass
 
 - ### If you have many related datasets designed for same project. You can use `project` decorator! One additional folder will be created for your project under experimental dir.
         @CLASSIFICATION_DATASETS.snapshot
         @CLASSIFICATION_DATASETS.project('Your_project_name')
         @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '/homes/my_dataset_fname.json')
-        def get_my_dataset(files_list, phase, opts):
+        def get_my_dataset(filelist, phase, opts):
             pass
 
 - ### Strix support multiple inputs/outputs now! Use `multi_in` & `multi_out` decorators. Make sure the keys are in the filelist (.json/.yaml).
         @CLASSIFICATION_DATASETS.snapshot
         @CLASSIFICATION_DATASETS.multi_in('image', 'mask')
         @CLASSIFICATION_DATASETS.register('2D', 'my_dataset', '/homes/my_dataset_fname.json')
-        def get_my_dataset(files_list, phase, opts):
+        def get_my_dataset(filelist, phase, opts):
             pass

--- a/strix/datasets/synthetic_dataset.py
+++ b/strix/datasets/synthetic_dataset.py
@@ -23,7 +23,7 @@ from strix.utilities.enum import Frameworks
 @SEGMENTATION_DATASETS.register("3D", "SyntheticData", None)
 @SELFLEARNING_DATASETS.register("2D", "SyntheticData", None)
 @SELFLEARNING_DATASETS.register("3D", "SyntheticData", None)
-def synthetic_dataset(files_list, phase, opts):
+def synthetic_dataset(filelist, phase, opts):
     if opts['output_nc'] in [1, 2]:
         seg_cls = 1
     elif opts['output_nc'] > 2:
@@ -50,7 +50,7 @@ def synthetic_dataset(files_list, phase, opts):
         )
 
     return BasicSegmentationDataset(
-        files_list,
+        filelist,
         loader=loader,
         channeler=EnsureChannelFirstD(keys=["image", "label"]),
         orienter=None,
@@ -71,7 +71,7 @@ def synthetic_dataset(files_list, phase, opts):
 
 @CLASSIFICATION_DATASETS.register("2D", "RandomData", None)
 @CLASSIFICATION_DATASETS.register("3D", "RandomData", None)
-def random_dataset_cls_nc1(files_list, phase, opts):
+def random_dataset_cls_nc1(filelist, phase, opts):
     if opts['output_nc'] in [1, 2]:
         out_cls = 1
     elif opts['output_nc'] > 2:
@@ -91,7 +91,7 @@ def random_dataset_cls_nc1(files_list, phase, opts):
         )
 
     return BasicClassificationDataset(
-        files_list,
+        filelist,
         loader=loader,
         channeler=EnsureChannelFirstD(keys="image"),
         orienter=None,

--- a/strix/tests/test_basicclassificationdataset.py
+++ b/strix/tests/test_basicclassificationdataset.py
@@ -18,7 +18,7 @@ filelist = [
 
 def test_basic_clf_dataset():
     data = BasicClassificationDataset(
-        files_list=filelist,
+        filelist=filelist,
         loader=lambda x: x,
         channeler=None,
         orienter=None,

--- a/strix/tests/test_siamesedataset
+++ b/strix/tests/test_siamesedataset
@@ -5,7 +5,7 @@ from utils_cw import get_items_from_file
 
 
 dataset = SIAMESE_DATASETS['2D']['jsph_mvi'](
-    files_list=get_items_from_file("/homes/clwang/Data/jsph_lung/MVI/data_crops/datalist-train.json"),
+    filelist=get_items_from_file("/homes/clwang/Data/jsph_lung/MVI/data_crops/datalist-train.json"),
     phase='valid', opts={})
 loader = DataLoader(dataset=dataset, batch_size=5)
 


### PR DESCRIPTION
Fixes: #38 

Rename `files_list` to `filelist` since the name `files_list` seems weird.
Readme.md have also been modified.

All current dataset may failed since the the argument renamed.

Author:    Chenglong Wang <ryuu.j.ching@gmail.com>

