### PR TITLE
Network registry

### DIFF
--- a/strix/models/__init__.py
+++ b/strix/models/__init__.py
@@ -1,21 +1,6 @@
-from pathlib import Path
 from utils_cw import check_dir
 import torch
 from strix.utilities.registry import NetworkRegistry
-
-CLASSIFICATION_ARCHI = NetworkRegistry()
-SEGMENTATION_ARCHI = NetworkRegistry()
-SELFLEARNING_ARCHI = NetworkRegistry()
-MULTITASK_ARCHI = NetworkRegistry()
-SIAMESE_ARCHI = NetworkRegistry()
-
-ARCHI_MAPPING = {
-    "segmentation": SEGMENTATION_ARCHI,
-    "classification": CLASSIFICATION_ARCHI,
-    "selflearning": SELFLEARNING_ARCHI,
-    "multitask": MULTITASK_ARCHI,
-    "siamese": SIAMESE_ARCHI,
-}
 
 from strix.models.cnn.utils import print_network, PolynomialLRDecay
 from strix.models.cnn.layers.radam import RAdam
@@ -24,7 +9,7 @@ from strix.models.cnn.engines import TRAIN_ENGINES, TEST_ENGINES, ENSEMBLE_TEST_
 from strix.data_io import DATASET_MAPPING
 from strix.utilities.utils import get_attr_
 from strix.models.cnn.losses import LOSS_MAPPING, ContrastiveLoss
-from strix.utilities.imports import import_file, ModuleManager
+from strix.utilities.imports import ModuleManager
 from strix.utilities.enum import Frameworks
 from strix.configures import config as cfg
 from strix.models.cnn.cnn_nets import *
@@ -95,15 +80,9 @@ def get_network(opts):
     n_group = options.pop("n_group", 1)  # used for multi-group archi
     pretrained_model_path = options.pop("pretrained_model_path", None)
 
-    siamese = None
-    siamese_latent_dim = options.pop("latent_dim", 512)
-    if ARCHI_MAPPING[opts.framework] == SIAMESE_ARCHI:
-        loss_type = LOSS_MAPPING[opts.framework][opts.criterion]
-        siamese = "single" if loss_type == ContrastiveLoss else "multi"
-        raise NotImplementedError
-
     try:
-        model = ARCHI_MAPPING[opts.framework][opts.tensor_dim][opts.model_name]
+        Networks = NetworkRegistry()
+        model = Networks[opts.tensor_dim][opts.framework][opts.model_name]
     except:
         raise ValueError(f"Cannot find registered model: {opts.model_name}")
     else:

--- a/strix/models/__init__.py
+++ b/strix/models/__init__.py
@@ -80,26 +80,25 @@ def get_network(opts):
     n_group = options.pop("n_group", 1)  # used for multi-group archi
     pretrained_model_path = options.pop("pretrained_model_path", None)
 
-    try:
-        Networks = NetworkRegistry()
-        model = Networks[opts.tensor_dim][opts.framework][opts.model_name]
-    except:
+    networks = NetworkRegistry()
+    model = networks.get(opts.tensor_dim, opts.framework, opts.model_name)
+    if model is None:
         raise ValueError(f"Cannot find registered model: {opts.model_name}")
-    else:
-        return model(
-            dim,
-            in_channels,
-            out_channels,
-            act,
-            norm,
-            n_depth,
-            n_group,
-            drop_out,
-            is_prunable,
-            pretrained,
-            pretrained_model_path,
-            **options,  # Todo: Only pass network-related kwargs instead of all
-        )
+    
+    return model(
+        dim,
+        in_channels,
+        out_channels,
+        act,
+        norm,
+        n_depth,
+        n_group,
+        drop_out,
+        is_prunable,
+        pretrained,
+        pretrained_model_path,
+        **options,  # Todo: Only pass network-related kwargs instead of all
+    )
 
 
 def get_engine(opts, train_loader, test_loader, writer=None):

--- a/strix/models/cnn/cnn_nets.py
+++ b/strix/models/cnn/cnn_nets.py
@@ -3,7 +3,7 @@ from typing import Any
 import os
 import torch
 
-from strix.models import CLASSIFICATION_ARCHI, SEGMENTATION_ARCHI, SELFLEARNING_ARCHI
+from strix.utilities.registry import NetworkRegistry
 from strix.models.cnn.nets.resnet import resnet18, resnet34, resnet50
 from strix.models.cnn.nets.vgg import vgg9_bn, vgg11_bn
 from strix.models.cnn.nets.dynunet import DynUNet
@@ -11,9 +11,10 @@ from strix.models.cnn.nets.drn import drn_a_50
 from strix.models.cnn.nets.hesam import HESAM
 from strix.models.cnn.nets.resnet_aag import resnet34_aag, resnet50_aag
 
+NETWORK = NetworkRegistry()
 
-@CLASSIFICATION_ARCHI.register("2D", "resnet18")
-@CLASSIFICATION_ARCHI.register("3D", "resnet18")
+@NETWORK.register("2D", "classification", "resnet18")
+@NETWORK.register("3D", "classification", "resnet18")
 def strix_resnet18(
     spatial_dims: int,
     in_channels: int,
@@ -37,8 +38,8 @@ def strix_resnet18(
     return resnet18(pretrained=False, progress=True, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "resnet34")
-@CLASSIFICATION_ARCHI.register("3D", "resnet34")
+@NETWORK.register("2D", "classification", "resnet34")
+@NETWORK.register("3D", "classification", "resnet34")
 def strix_resnet50(
     spatial_dims: int,
     in_channels: int,
@@ -62,8 +63,8 @@ def strix_resnet50(
     return resnet34(pretrained=False, progress=True, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "resnet50")
-@CLASSIFICATION_ARCHI.register("3D", "resnet50")
+@NETWORK.register("2D", "classification", "resnet50")
+@NETWORK.register("3D", "classification", "resnet50")
 def strix_resnet50(
     spatial_dims: int,
     in_channels: int,
@@ -87,8 +88,8 @@ def strix_resnet50(
     return resnet50(pretrained=False, progress=True, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "vgg9")
-@CLASSIFICATION_ARCHI.register("3D", "vgg9")
+@NETWORK.register("2D", "classification", "vgg9")
+@NETWORK.register("3D", "classification", "vgg9")
 def strix_vgg9_bn(
     spatial_dims: int,
     in_channels: int,
@@ -114,8 +115,8 @@ def strix_vgg9_bn(
     return vgg9_bn(pretrained=False, progress=True, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "vgg11")
-@CLASSIFICATION_ARCHI.register("3D", "vgg11")
+@NETWORK.register("2D", "classification", "vgg11")
+@NETWORK.register("3D", "classification", "vgg11")
 def strix_vgg11_bn(
     spatial_dims: int,
     in_channels: int,
@@ -141,8 +142,8 @@ def strix_vgg11_bn(
     return vgg11_bn(pretrained=False, progress=True, **inkwargs)
 
 
-@SELFLEARNING_ARCHI.register('2D', 'unet')
-@SELFLEARNING_ARCHI.register('3D', 'unet')
+@NETWORK.register('2D', "selflearning", "unet")
+@NETWORK.register('3D', "selflearning", "unet")
 def strix_dyn_unet(
     spatial_dims: int,
     in_channels: int,
@@ -186,8 +187,8 @@ def strix_dyn_unet(
     )
 
 
-@SEGMENTATION_ARCHI.register("2D", "unet")
-@SEGMENTATION_ARCHI.register("3D", "unet")
+@NETWORK.register("2D", "segmentation", "unet")
+@NETWORK.register("3D", "segmentation", "unet")
 def strix_dyn_unet(
     spatial_dims: int,
     in_channels: int,
@@ -231,8 +232,8 @@ def strix_dyn_unet(
     )
 
 
-@SEGMENTATION_ARCHI.register("2D", "res-unet")
-@SEGMENTATION_ARCHI.register("3D", "res-unet")
+@NETWORK.register("2D", "segmentation", "res-unet")
+@NETWORK.register("3D", "segmentation", "res-unet")
 def strix_dyn_resunet(
     spatial_dims: int,
     in_channels: int,
@@ -276,8 +277,8 @@ def strix_dyn_resunet(
     )
 
 
-@CLASSIFICATION_ARCHI.register("2D", "DRN_a50")
-@CLASSIFICATION_ARCHI.register("3D", "DRN_a50")
+@NETWORK.register("2D", "classification", "DRN_a50")
+@NETWORK.register("3D", "classification", "DRN_a50")
 def strix_drn_a_50(
     spatial_dims: int,
     in_channels: int,
@@ -299,8 +300,8 @@ def strix_drn_a_50(
     return drn_a_50(pretrained=False, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "HESAM")
-@CLASSIFICATION_ARCHI.register("3D", "HESAM")
+@NETWORK.register("2D", "classification", "HESAM")
+@NETWORK.register("3D", "classification", "HESAM")
 def strix_hesam(
     spatial_dims: int,
     in_channels: int,
@@ -344,8 +345,8 @@ def strix_hesam(
     return net
 
 
-@CLASSIFICATION_ARCHI.register("2D", "resnet_aag_34")
-@CLASSIFICATION_ARCHI.register("3D", "resnet_aag_34")
+@NETWORK.register("2D", "classification", "resnet_aag_34")
+@NETWORK.register("3D", "classification", "resnet_aag_34")
 def strix_resnetaag_34(
     spatial_dims: int,
     in_channels: int,
@@ -381,8 +382,8 @@ def strix_resnetaag_34(
     return resnet34_aag(pretrained_model_path, **inkwargs)
 
 
-@CLASSIFICATION_ARCHI.register("2D", "resnet_aag_50")
-@CLASSIFICATION_ARCHI.register("3D", "resnet_aag_50")
+@NETWORK.register("2D", "classification", "resnet_aag_50")
+@NETWORK.register("3D", "classification", "resnet_aag_50")
 def strix_resnetaag_50(
     spatial_dims: int,
     in_channels: int,

--- a/strix/models/cnn/nets/hesam.py
+++ b/strix/models/cnn/nets/hesam.py
@@ -359,8 +359,6 @@ class HESAM(nn.Module):
         return logits
 
 
-# @CLASSIFICATION_ARCHI.register('2D', 'nnHESAM')
-# @CLASSIFICATION_ARCHI.register('3D', 'nnHESAM')
 class HESAM2(nn.Module):
     def __init__(
         self,

--- a/strix/models/cnn/nets/mg_unet.py
+++ b/strix/models/cnn/nets/mg_unet.py
@@ -6,8 +6,6 @@ from strix.models.cnn.nets.dynunet import DynUNet
 from strix.models.cnn.blocks.dynunet_block_ex import *
 
 
-# @SEGMENTATION_ARCHI.register('2D', 'mg_unet')
-# @SEGMENTATION_ARCHI.register('3D', 'mg_unet')
 class MG_Unet(DynUNet):
     def __init__(
         self,

--- a/strix/models/transformer/transformer_nets.py
+++ b/strix/models/transformer/transformer_nets.py
@@ -1,14 +1,12 @@
 from typing import Any
 
-import os
-import torch
-
-from strix.models import SEGMENTATION_ARCHI
+from strix.utilities.registry import NetworkRegistry
 from monai_ex.networks.nets import UNETR
 
+NETWORK = NetworkRegistry()
 
-@SEGMENTATION_ARCHI.register("2D", "UNETR")
-@SEGMENTATION_ARCHI.register("3D", "UNETR")
+@NETWORK.register("2D", "segmentation", "UNETR")
+@NETWORK.register("3D", "segmentation", "UNETR")
 def strix_unetr(
     spatial_dims: int,
     in_channels: int,

--- a/strix/tests/test_classification_engine.py
+++ b/strix/tests/test_classification_engine.py
@@ -4,7 +4,7 @@ import torch
 
 from strix.models.cnn.engines.classification_engines import ClassificationTestEngine
 from strix.models.cnn.nets.dynunet import DynUNet as UNet
-from strix.models import CLASSIFICATION_ARCHI
+from strix.utilities.registry import NetworkRegistry
 from strix.utilities.enum import Phases
 from torch.optim import SGD, lr_scheduler
 from strix.models.cnn.losses import DiceLoss
@@ -28,7 +28,8 @@ class TestClassification:
     @pytest.mark.parametrize("save_prob", [True, False])
     def test_segmentatation_test_engine(self, device, phase, dim, save_img, save_prob, tmp_path):
         dataset_fn = CLASSIFICATION_DATASETS[f"{dim}D"]["RandomData"]["FN"]
-        net = CLASSIFICATION_ARCHI[f"{dim}D"]["vgg9"](
+        Networks = NetworkRegistry()
+        net = Networks[f"{dim}D"]["classificaton"]["vgg9"](
             spatial_dims=dim,
             in_channels=1,
             out_channels=1,

--- a/strix/tests/test_freeze_network.py
+++ b/strix/tests/test_freeze_network.py
@@ -3,12 +3,14 @@ import pytest
 import torch
 import torch.nn as nn
 
-from strix.models import ARCHI_MAPPING
+from strix.utilities.registry import NetworkRegistry
 from strix.models.cnn.utils import set_trainable, count_trainable_params
+
 
 @pytest.mark.parametrize("freeze", [True, False])
 def test_segmentation_train_engine(freeze):
-    model_type = ARCHI_MAPPING["multitask"]["3D"]["UnifiedNet-M3"]
+    Networks = NetworkRegistry()
+    model_type = Networks["3D"]["multitask"]["UnifiedNet-M3"]
     net = model_type(
         3,
         1,

--- a/strix/utilities/click_callbacks.py
+++ b/strix/utilities/click_callbacks.py
@@ -15,17 +15,16 @@ from termcolor import colored
 
 import strix.utilities.oyaml as yaml
 from strix.data_io import DATASET_MAPPING
-from strix.models import ARCHI_MAPPING
+from strix.utilities.registry import NetworkRegistry
 from strix.models.cnn.losses import LOSS_MAPPING
-from strix.utilities.enum import BUILTIN_TYPES, FRAMEWORKS, Frameworks
+from strix.utilities.enum import BUILTIN_TYPES, FRAMEWORKS, Frameworks, Freezers
 from strix.utilities.utils import get_items, is_avaible_size, save_sourcecode, warning_on_one_line
+from strix.utilities.click import NumericChoice
+from strix.utilities.project_loader import ProjectManager
 
 warnings.formatwarning = warning_on_one_line
 from utils_cw import Print, check_dir
 
-from strix.utilities.click import NumericChoice
-from strix.utilities.enum import BUILTIN_TYPES, Freezers
-from strix.utilities.project_loader import ProjectManager
 
 #######################################################################
 
@@ -390,7 +389,8 @@ def loss_select(ctx, param, value, prompt_all_args=False):
 
 
 def model_select(ctx, param, value):
-    archilist = list(ARCHI_MAPPING[ctx.params["framework"]][ctx.params["tensor_dim"]].keys())
+    Networks = NetworkRegistry()
+    archilist = list(Networks[ctx.params["tensor_dim"]][ctx.params["framework"]].keys())
     if len(archilist) == 0:
         print(f"No architecture available for {ctx.params['tensor_dim']} " f"{ctx.params['framework']} task! Abort!")
         ctx.exit()
@@ -621,8 +621,9 @@ def check_freeze_api(ctx_params):
         and ctx_params.get("framework")
         and ctx_params.get("tensor_dim")
         and ctx_params.get("model_name")
-    ):
-        model = ARCHI_MAPPING[ctx_params["framework"]][ctx_params["tensor_dim"]][ctx_params["model_name"]]
+    ):  
+        Networks = NetworkRegistry()
+        model = Networks[ctx_params["tensor_dim"]][ctx_params["framework"]][ctx_params["model_name"]]
         warning_msg = colored(
             f"freeze() member function is not detected in '{model.__name__}', freeze wont work!", "red"
         )

--- a/strix/utilities/click_callbacks.py
+++ b/strix/utilities/click_callbacks.py
@@ -389,16 +389,16 @@ def loss_select(ctx, param, value, prompt_all_args=False):
 
 
 def model_select(ctx, param, value):
-    Networks = NetworkRegistry()
-    archilist = list(Networks[ctx.params["tensor_dim"]][ctx.params["framework"]].keys())
-    if len(archilist) == 0:
+    networks = NetworkRegistry()
+    net_list = networks.list(ctx.params["tensor_dim"], ctx.params["framework"])
+    if len(net_list) == 0:
         print(f"No architecture available for {ctx.params['tensor_dim']} " f"{ctx.params['framework']} task! Abort!")
         ctx.exit()
 
-    if value is not None and value in archilist:
+    if value is not None and value in net_list:
         return value
     else:
-        return prompt("Model list", type=NumericChoice(archilist))
+        return prompt("Model list", type=NumericChoice(net_list))
 
 
 def data_select(ctx, param, value):

--- a/strix/utilities/click_callbacks.py
+++ b/strix/utilities/click_callbacks.py
@@ -680,6 +680,6 @@ def backup_project(ctx_params):
         return True
 
     pm = ProjectManager()
-    if pm.project_file.is_file():
+    if pm.project_file and pm.project_file.is_file():
         save_sourcecode(pm.project_file.parent, out_dir, verbose=False)
     return True

--- a/strix/utilities/registry.py
+++ b/strix/utilities/registry.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 import os
 import inspect
@@ -146,6 +146,46 @@ class NetworkRegistry(DimRegistry):
             return fn
 
         return register_fn
+
+    def get(self, dim: Union[int, str], framework: str, name: str):
+        """alias of direct access by `[]`
+
+        Args:
+            dim (int | str): tensor dim
+            framework (str): framework type, eg. segmentation
+            name (str): network name which has been register
+
+        Returns:
+            Net: speificed network.
+            None: if no network is found.
+        """
+        try:
+            dim = self.dim_mapping.get(dim)
+            net = self[dim][framework][name]
+        except KeyError as e:
+            warnings.warn(colored(f"Network is not registered!\nErr msg: {e}", "red"))
+            return None
+        else:
+            return net
+
+    def list(self, dim: Union[int, str], framework: str):
+        """List all registered networks by given dim and framework
+
+        Args:
+            dim (Union[int, str]): tensor dim
+            framework (str): framework type, eg. classification
+
+        Returns:
+            list: if no network is found, return empty list [].
+        """
+        try:
+            dim = self.dim_mapping.get(dim)
+            nets = list(self[dim][framework].keys())
+        except KeyError as e:
+            warnings.warn(colored(f"Key error!\nErr msg: {e}", "red"))
+            return []
+        else:
+            return nets
 
 
 class DatasetRegistry(DimRegistry):

--- a/strix/utilities/registry.py
+++ b/strix/utilities/registry.py
@@ -2,7 +2,10 @@ from typing import Optional
 
 import os
 import inspect
-from strix.utilities.enum import DIMS, NETWORK_ARGS
+import warnings
+from termcolor import colored
+from strix.utilities.enum import DIMS, NETWORK_ARGS, FRAMEWORKS
+from strix.utilities.utils import singleton
 
 
 def _register_generic(module_dict, module_name, module):
@@ -16,6 +19,15 @@ def _register_generic_dim(module_dict, dim, module_name, module):
     ), f"{module_name} already registed in {module_dict.get(dim)}"
 
     module_dict[dim].update({module_name: module})
+
+
+def _register_network(module_dict, dim, framework, module_name, module):
+    if module_name in module_dict[dim][framework]:
+        warnings.warn(colored(f"{module_name} already registed! Skip!", "yellow"))
+        return False
+
+    module_dict[dim][framework].update({module_name: module})
+    return True
 
 
 def _register_generic_data(
@@ -84,8 +96,8 @@ class DimRegistry(dict):
         self["3D"] = {}
 
     def register(self, dim, module_name, module=None):
+        dim = self.dim_mapping.get(dim)
         assert dim in DIMS, "Only support '2D'&'3D' dataset now"
-        dim = self.dim_mapping[dim]
         # used as function call
         if module is not None:
             _register_generic_dim(self, dim, module_name, module)
@@ -99,9 +111,13 @@ class DimRegistry(dict):
         return register_fn
 
 
+@singleton
 class NetworkRegistry(DimRegistry):
     def __init__(self, *args, **kwargs):
-        super(NetworkRegistry, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
+        for dim in DIMS:
+            for framework in FRAMEWORKS:
+                self[dim].update({framework: {}})
 
     def check_args(self, func, module_name):
         sig = inspect.signature(func)
@@ -112,19 +128,21 @@ class NetworkRegistry(DimRegistry):
                     f"Missing argument {arg} in your {module_name} network API funcion"
                 )
 
-    def register(self, dim, module_name, module=None):
+    def register(self, dim, framework, module_name, module=None):
+        dim = self.dim_mapping.get(dim)
         assert dim in DIMS, "Only support '2D'&'3D' dataset now"
-        dim = self.dim_mapping[dim]
+        assert framework in FRAMEWORKS, f"Given '{framework}' is not supported yet!"
+        
         # used as function call
         if module is not None:
             self.check_args(module, module_name)
-            _register_generic_dim(self, dim, module_name, module)
+            _register_network(self, dim, framework, module_name, module)
             return
 
         # used as decorator
         def register_fn(fn):
             self.check_args(fn, module_name)
-            _register_generic_dim(self, dim, module_name, fn)
+            _register_network(self, dim, framework, module_name, fn)
             return fn
 
         return register_fn


### PR DESCRIPTION
Close: #31 

Change "NetworkRegistry" to singleton.
Instead of instantiating each architecture separately, Now networks should be accessed by using `networks = NetworkRegistry()`

E.g., to access classification network, use `net = networks['2D']['classification']['resnet_18']` or `net = networks.get('2D', 'classification', 'resnet_18')`.  to list registered networks, use `net = networks.list('2D', 'segmentation')`

